### PR TITLE
Adding capabilities support

### DIFF
--- a/irc-socket.js
+++ b/irc-socket.js
@@ -107,6 +107,7 @@ var Socket = module.exports = function Socket (network, GenericSocket) {
 
         socket.impl.once('close', function () {
             socket.connected = false;
+            socket.emit('close');
         });
 
         socket.impl.on('data', onData);


### PR DESCRIPTION
This doesn't add actual support for it, just lets you choose whether to send a CAP LS out at the start of the handshake, there's no other way to implement it, I tried hooking onto the `connect` event or removing all the listeners and re-adding them but it feels a bit hacky.

This just takes the `capab` option in the `network` object, if it's `true` it'll send out CAP LS, if not it won't. Clients can handle anything else on their own.

**Edit:** I've added the option to send a password through aswell if anyone ever needs to use it.

**Edit again:** I've added emitting an event on the `Socket` object when the connection is closed. This lets people using the library do something with that, such as reconnect or whatever. This saves me doing `connection.impl.on('close')` when all the other events are just `connection.on()`.
