### PR TITLE
Added error event

### DIFF
--- a/irc-socket.js
+++ b/irc-socket.js
@@ -105,12 +105,12 @@ var Socket = module.exports = function Socket (network, GenericSocket) {
             socket.impl.on(emitEvent, emitWhenConnected);
         }();
 
-        socket.impl.once('error', function () {
+        socket.impl.on('error', function () {
             socket.connected = false;
             socket.emit('error');
         });
 
-        socket.impl.once('close', function () {
+        socket.impl.on('close', function () {
             socket.connected = false;
             socket.emit('close');
         });


### PR DESCRIPTION
I've added an error event because I was listening on `IrcSocket.impl.on('error')` and it seemed a bit messy. I've also changed these events to on instead of once incase someone decides to call `connect()` again later down the line without re initiating the object and a close or error happens again it wont bubble down.
