### PR TITLE
Expose localPort and a connect event to allow built in identd servers

### DIFF
--- a/irc-socket.js
+++ b/irc-socket.js
@@ -36,6 +36,7 @@ var Socket = module.exports = function Socket (config, NetSocket) {
     socket.rejectUnauthorized = config.rejectUnauthorized || false;
     socket.network = config; // FIXME: Only put specific values on the network object.
     socket.impl = new NetSocket();
+    socket.localPort = socket.impl.localPort;
     socket.connected = false;
 
     socket._setupEvents = function () {
@@ -83,6 +84,7 @@ var Socket = module.exports = function Socket (config, NetSocket) {
         void function connectEvent () {
             var emitEvent = (socket.secure) ? 'secureConnect' : 'connect';
             var emitWhenConnected = function () {
+                socket.emit('connect');
                 socket.connected = true;
 
                 if (socket.network.capab) {


### PR DESCRIPTION
This is just a tiny change to expose `localPort` instead of having to do `socket.impl.localPort` so anyone can access that information if they need to, say when building an identd server.

It also exposes the underlying `connect` event when a connection is established.
