### PR TITLE
Add smiley support :D

### DIFF
--- a/irc-socket.js
+++ b/irc-socket.js
@@ -56,7 +56,7 @@ var Socket = module.exports = function Socket (config, NetSocket) {
             .filter(function (line) { return line !== ''; })
             .filter(function (line) {
                 if (line.slice(0, 4) === 'PING') {
-                    socket.raw(['PONG', line.slice(line.indexOf(':'))]);
+                    socket.raw(['PONG', line.slice(line.indexOf(':'))].join(' '));
                 }
 
                 return true;
@@ -168,8 +168,14 @@ Socket.prototype = create(events.EventEmitter.prototype, {
         }
 
         if (Array.isArray(message)) {
-            message = message.map(function (m) {
-                return (m.indexOf(' ') !== -1) ? ':' + m : m;
+            message = message.map(function (m, index) {
+                // Prepend a : if parameter has a space or if it's the last element and starts with :.
+                if (m.indexOf(' ') !== -1 ||
+                    (index === (message.length - 1) && m[0] === ':')) {
+                    return ':' + m;
+                } else {
+                    return m;
+                }
             }).join(' ');
         }
 

--- a/spec/irc-socket.spec.js
+++ b/spec/irc-socket.spec.js
@@ -151,4 +151,17 @@ describe("IRC Sockets", function () {
             });
         });
     });
+
+    describe("Smiley", function () {
+        it('Sends raw smiley face', function () {
+            var genericsocket = MockGenericSocket();
+            var socket = IrcSocket(network, box(genericsocket));
+            socket.connect();
+            socket.raw(['PRIVMSG', '#smiley-test', ':)']);
+            socket.end();
+            expect(genericsocket.write).toHaveBeenCalledWith('NICK testbot\r\n', 'utf-8');
+            expect(genericsocket.write).toHaveBeenCalledWith('USER testuser 8 * realbot\r\n', 'utf-8');
+            expect(genericsocket.write).toHaveBeenCalledWith('PRIVMSG #smiley-test ::)\r\n', 'utf-8');
+        });
+    });
 });


### PR DESCRIPTION
I noticed that when I tried to send smiley faces through [IRCanywhere](https://github.com/ircanywhere/ircanywhere)'s web interface, they came up half-decapitated from the the eyes up. I traced the culprit back to `irc-socket`. This patch stops this bloodshed by adding an extra `:` when the last parameter to a message starts with `:`.

Note that this [pull request to `irc-message`](https://github.com/expr/irc-message/pull/12) is pretty similar too. Let's bring back the laughter to IRC.